### PR TITLE
Updated broken dependencies that were preventing compilation on newer versions of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,4 @@ built = "0.5"
 color-eyre = "0.5"
 env_logger = "0.9"
 eyre = "0.6"
-tokio = {version = "1.1", features = ["rt-multi-thread", "macros", "sync"]}
+tokio = {version = "1.28.0", features = ["rt-multi-thread", "macros", "sync"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ version = "0.3.5"
 [dependencies]
 # async
 async-trait = "0.1"
-tokio = {version = "1.28.0", features = ["rt-multi-thread", "sync"]}
+tokio = {version = "1.2", features = ["macros", "rt-multi-thread", "sync"]}
+
 
 # actor framework
 act-zero = {version = "0.4", features = ["default-tokio"]}
@@ -39,7 +40,7 @@ rand = "0.8"
 # node information
 get_if_addrs = "0.5.3"
 hostname = "0.3"
-sysinfo = "0.19"
+sysinfo = "0.27.0"
 
 # utils
 ctrlc = {version = "3.0", features = ["termination"]}
@@ -56,4 +57,3 @@ built = "0.5"
 color-eyre = "0.5"
 env_logger = "0.9"
 eyre = "0.6"
-tokio = {version = "1.28.0", features = ["rt-multi-thread", "macros", "sync"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.3.5"
 [dependencies]
 # async
 async-trait = "0.1"
-tokio = {version = "1.2", features = ["rt-multi-thread", "sync"]}
+tokio = {version = "1.28.0", features = ["rt-multi-thread", "sync"]}
 
 # actor framework
 act-zero = {version = "0.4", features = ["default-tokio"]}


### PR DESCRIPTION
ntapi < 0.4 does not compile in newer versions of Rust. This is a dependency of sysinfo.

Updating sysinfo resolved the issue, but came with some API changes that caused issues, resolved these too.